### PR TITLE
Do not package tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     },
     python_requires=">=3.6",
     url="https://github.com/adamltyson/slurmio",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=("tests",)),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Operating System :: POSIX :: Linux",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     },
     python_requires=">=3.6",
     url="https://github.com/adamltyson/slurmio",
-    packages=setuptools.find_packages(exclude=("tests",)),
+    packages=setuptools.find_packages(exclude=("tests", "tests.*")),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
Right not the `tests/` folders will be installed to the root `site-packages` where it can clobber (due to the same accidental error) other packages data. This is not ideal and should be changed if possible. Submitting this as part of the submission to conda-forge review.